### PR TITLE
Add WalletStakeButtons and use in chain page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Network configuration data (networks.json, markdown content for each chain) live
 | `staking-dev` | Next.js source code — development branch |
 | `config` | Network configs: `networks.json`, per-chain `.md` files, global templates |
 | `chain-images` | Chain logo/icon images |
+| `feature/wallet-stake-buttons` | Source branch — wallet staking buttons feature |
+| `feature/wallet-stake-buttons-config` | Config branch — wallet metadata for buttons |
 
 ## Tech Stack
 
@@ -52,7 +54,8 @@ src/
 │   │   │   ├── reset-filters.tsx # Reset all filters button
 │   │   │   ├── player.tsx        # Audio player component
 │   │   │   ├── social-icons.tsx  # Social media icon links
-│   │   │   └── validator-links.tsx # Validator-related links
+│   │   │   ├── validator-links.tsx # Validator-related links
+│   │   │   └── wallet-stake-buttons.tsx # Per-wallet staking buttons (Keplr, Leap, etc.)
 │   │   ├── common/
 │   │   │   ├── button.tsx        # Styled button component
 │   │   │   └── switch.tsx        # Toggle switch
@@ -94,9 +97,22 @@ Each network in `networks.json`:
   "title": "Cosmos",
   "icon": "https://...",
   "stake": "https://...",
+  "validator_address": "cosmosvaloper1...",
+  "mintscan_name": "cosmos",
+  "wallets": [
+    { "name": "Keplr", "url": "https://wallet.keplr.app/?modal=staking&chain=...&validator_address=..." },
+    { "name": "Ping.pub", "url": "https://ping.pub/cosmos/staking/cosmosvaloper1..." }
+  ],
   "services": ["public-goods", "peers", "snapshot"]
 }
 ```
+
+### Wallet Buttons Logic
+
+- `WalletStakeButtons` component renders one button per entry in `wallets[]`
+- Each button links directly to our validator where the wallet supports deep-linking
+- For wallets without direct validator links (Leap, Cosmostation), URLs point to the staking dashboard
+- Non-Cosmos chains (Namada, Aztec) use their native staking interfaces
 
 ## Environment Variables
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ docker run -p 3000:3000 staking         # Run container (port 3000)
 | Social icons | `src/app/components/chain-list/social-icons.tsx` |
 | Validator links | `src/app/components/chain-list/validator-links.tsx` |
 | Audio player | `src/app/components/chain-list/player.tsx` |
+| Wallet stake buttons | `src/app/components/chain-list/wallet-stake-buttons.tsx` |
 | Health check API | `src/app/api/health/[chainName]/route.ts` |
 | Filter logic | `src/app/utils/chain-list/filters-utils.ts` |
 | Data fetching | `src/app/actions/repos.ts` |
@@ -52,6 +53,7 @@ docker run -p 3000:3000 staking         # Run container (port 3000)
 - `FC<Props>` pattern with named interfaces (`OwnProps`)
 - Absolute imports via `@/` alias (mapped to `src/`)
 - Config fetched at runtime from GitHub raw content URLs
+- Wallet staking buttons driven by `wallets[]` array in config `networks.json`
 
 ## Gotchas
 

--- a/src/app/chains/[chain]/page.tsx
+++ b/src/app/chains/[chain]/page.tsx
@@ -55,13 +55,13 @@ const ChainPage = async (props: OwnProps) => {
           <h1 className="mb-10 ml-10 text-nowrap text-3xl font-semibold">{data.title}</h1>
           <div className="flex flex-row">
             <Image src={data.icon} alt={data.title} width={180} height={180} />
-            <div className="ml-12 flex flex-col items-center justify-center">
+            <div className="ml-12 flex flex-col justify-center">
               <div>
                 <div className="mt-4">
-                  <WalletStakeButtons stake={data.stake} wallets={data.wallets} />
+                  <WalletStakeButtons wallets={data.wallets} />
                 </div>
-                <div className="flex flex-row items-center justify-center">
-                  <div className="mt-6 flex space-x-4">
+                <div className="mt-6 flex flex-row items-center">
+                  <div className="flex space-x-4">
                     <Link
                       title={`${data.title} explorer`}
                       href={`https://validatorinfo.com/networks/${data.name}/overview`}

--- a/src/app/chains/[chain]/page.tsx
+++ b/src/app/chains/[chain]/page.tsx
@@ -11,7 +11,7 @@ import {
 import NotFound from '@/app/chains/[chain]/not-found';
 import StatusSwitch from '@/app/chains/[chain]/status-switch';
 import Tabs from '@/app/chains/[chain]/tabs';
-import Button from '@/app/components/common/button';
+import WalletStakeButtons from '@/app/components/chain-list/wallet-stake-buttons';
 import type { IChainConfig } from '@/types';
 
 interface OwnProps {
@@ -57,14 +57,8 @@ const ChainPage = async (props: OwnProps) => {
             <Image src={data.icon} alt={data.title} width={180} height={180} />
             <div className="ml-12 flex flex-col items-center justify-center">
               <div>
-                <div className="mt-4 flex space-x-8">
-                  {data.stake && (
-                    <Link href={data.stake} rel="nofollow" target="_blank">
-                      <Button external className="text-lg capitalize">
-                        Stake with Citizen Web3
-                      </Button>
-                    </Link>
-                  )}
+                <div className="mt-4">
+                  <WalletStakeButtons stake={data.stake} wallets={data.wallets} />
                 </div>
                 <div className="flex flex-row items-center justify-center">
                   <div className="mt-6 flex space-x-4">

--- a/src/app/components/chain-list/wallet-stake-buttons.tsx
+++ b/src/app/components/chain-list/wallet-stake-buttons.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { FC } from 'react';
+
+import Button from '@/app/components/common/button';
+
+interface OwnProps {
+  stake?: string;
+  wallets?: Array<{ name: string; url: string }>;
+}
+
+const WalletStakeButtons: FC<OwnProps> = ({ stake, wallets }) => {
+  if (!stake && (!wallets || wallets.length === 0)) return null;
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {stake && (
+        <Link href={stake} rel="nofollow" target="_blank">
+          <Button external className="text-lg capitalize">
+            Stake with Citizen Web3
+          </Button>
+        </Link>
+      )}
+      {wallets?.map((wallet) => (
+        <Link key={wallet.name} href={wallet.url} rel="nofollow" target="_blank">
+          <Button external className="text-lg capitalize">
+            Stake with {wallet.name}
+          </Button>
+        </Link>
+      ))}
+    </div>
+  );
+};
+
+export default WalletStakeButtons;

--- a/src/app/components/chain-list/wallet-stake-buttons.tsx
+++ b/src/app/components/chain-list/wallet-stake-buttons.tsx
@@ -4,22 +4,14 @@ import { FC } from 'react';
 import Button from '@/app/components/common/button';
 
 interface OwnProps {
-  stake?: string;
   wallets?: Array<{ name: string; url: string }>;
 }
 
-const WalletStakeButtons: FC<OwnProps> = ({ stake, wallets }) => {
-  if (!stake && (!wallets || wallets.length === 0)) return null;
+const WalletStakeButtons: FC<OwnProps> = ({ wallets }) => {
+  if (!wallets || wallets.length === 0) return null;
 
   return (
     <div className="flex flex-wrap gap-3">
-      {stake && (
-        <Link href={stake} rel="nofollow" target="_blank">
-          <Button external className="text-lg capitalize">
-            Stake with Citizen Web3
-          </Button>
-        </Link>
-      )}
       {wallets?.map((wallet) => (
         <Link key={wallet.name} href={wallet.url} rel="nofollow" target="_blank">
           <Button external className="text-lg capitalize">

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,6 +12,9 @@ export interface IChainConfig {
   addrbookUrl?: string;
   twitter?: string;
   discord?: string;
+  validator_address?: string;
+  mintscan_name?: string;
+  wallets?: Array<{ name: string; url: string }>;
   services: string[];
   generatedServices: string[];
   showTopChainEndpoints?: boolean;


### PR DESCRIPTION
Introduce a new WalletStakeButtons component to render stake and wallet links as buttons, and replace the inline stake button in the chain page with this reusable component. Update IChainConfig to include validator_address, mintscan_name, and wallets (array of {name, url}) so wallet links are properly typed.